### PR TITLE
Set graffiti to max 32 characters

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -67,7 +67,7 @@ exec -c /home/user/nimbus-eth2/build/nimbus_beacon_node \
     --keymanager-port=${VALIDATOR_PORT} \
     --keymanager-address=0.0.0.0 \
     --keymanager-token-file=${TOKEN_FILE} \
-    --graffiti="$GRAFFITI" \
+    --graffiti="${GRAFFITI:0:32}" \
     --jwt-secret=/jwtsecret \
     --web3-url=$HTTP_ENGINE \
     --suggested-fee-recipient="${FEE_RECIPIENT_ADDRESS}" \


### PR DESCRIPTION
Even though we set maximum length of graffiti in setup wizard, that value can be edited through config tab after package is installed. If value is longer than 32 characters, validator will not start and that is a pretty significant issue. This ensures that graffiti message is cropped and that validator starts